### PR TITLE
Decouple from IOInterface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .composer-attribute-collector
 .phpunit.result.cache
+build
 composer.lock
 vendor

--- a/src/ClassAttributeCollector.php
+++ b/src/ClassAttributeCollector.php
@@ -3,7 +3,6 @@
 namespace olvlvl\ComposerAttributeCollector;
 
 use Attribute;
-use Composer\IO\IOInterface;
 use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
@@ -14,7 +13,7 @@ use ReflectionException;
 class ClassAttributeCollector
 {
     public function __construct(
-        private IOInterface $io,
+        private Logger $log,
     ) {
     }
 
@@ -45,7 +44,7 @@ class ClassAttributeCollector
                 continue;
             }
 
-            $this->io->debug("Found attribute {$attribute->getName()} on $class");
+            $this->log->debug("Found attribute {$attribute->getName()} on $class");
 
             $classAttributes[] = new TransientTargetClass(
                 $attribute->getName(),
@@ -63,7 +62,7 @@ class ClassAttributeCollector
 
                 $method = $methodReflection->name;
 
-                $this->io->debug("Found attribute {$attribute->getName()} on $class::$method");
+                $this->log->debug("Found attribute {$attribute->getName()} on $class::$method");
 
                 $methodAttributes[] = new TransientTargetMethod(
                     $attribute->getName(),
@@ -84,7 +83,7 @@ class ClassAttributeCollector
                 $property = $propertyReflection->name;
                 assert($property !== '');
 
-                $this->io->debug("Found attribute {$attribute->getName()} on $class::$property");
+                $this->log->debug("Found attribute {$attribute->getName()} on $class::$property");
 
                 $propertyAttributes[] = new TransientTargetProperty(
                     $attribute->getName(),

--- a/src/Datastore/FileDatastore.php
+++ b/src/Datastore/FileDatastore.php
@@ -2,8 +2,8 @@
 
 namespace olvlvl\ComposerAttributeCollector\Datastore;
 
-use Composer\IO\IOInterface;
 use olvlvl\ComposerAttributeCollector\Datastore;
+use olvlvl\ComposerAttributeCollector\Logger;
 use olvlvl\ComposerAttributeCollector\Plugin;
 
 use function file_exists;
@@ -29,7 +29,7 @@ final class FileDatastore implements Datastore
      */
     public function __construct(
         private string $dir,
-        private IOInterface $io,
+        private Logger $log,
     ) {
         if (!is_dir($dir)) {
             mkdir($dir);
@@ -70,7 +70,7 @@ final class FileDatastore implements Datastore
         set_error_handler(function (int $errno, string $errstr) use (&$errored, $filename): bool {
             $errored = true;
 
-            $this->io->warning("Unable to unserialize cache item $filename: $errstr");
+            $this->log->warning("Unable to unserialize cache item $filename: $errstr");
 
             return true;
         });

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -2,8 +2,6 @@
 
 namespace olvlvl\ComposerAttributeCollector;
 
-use Composer\IO\IOInterface;
-
 /**
  * @internal
  */
@@ -12,5 +10,5 @@ interface Filter
     /**
      * @param class-string $class
      */
-    public function filter(string $filepath, string $class, IOInterface $io): bool;
+    public function filter(string $filepath, string $class, Logger $log): bool;
 }

--- a/src/Filter/Chain.php
+++ b/src/Filter/Chain.php
@@ -2,8 +2,8 @@
 
 namespace olvlvl\ComposerAttributeCollector\Filter;
 
-use Composer\IO\IOInterface;
 use olvlvl\ComposerAttributeCollector\Filter;
+use olvlvl\ComposerAttributeCollector\Logger;
 
 final class Chain implements Filter
 {
@@ -15,10 +15,10 @@ final class Chain implements Filter
     ) {
     }
 
-    public function filter(string $filepath, string $class, IOInterface $io): bool
+    public function filter(string $filepath, string $class, Logger $log): bool
     {
         foreach ($this->filters as $filter) {
-            if ($filter->filter($filepath, $class, $io) === false) {
+            if ($filter->filter($filepath, $class, $log) === false) {
                 return false;
             }
         }

--- a/src/Filter/ContentFilter.php
+++ b/src/Filter/ContentFilter.php
@@ -2,8 +2,8 @@
 
 namespace olvlvl\ComposerAttributeCollector\Filter;
 
-use Composer\IO\IOInterface;
 use olvlvl\ComposerAttributeCollector\Filter;
+use olvlvl\ComposerAttributeCollector\Logger;
 
 use function assert;
 use function file_get_contents;
@@ -13,7 +13,7 @@ use function str_contains;
 
 final class ContentFilter implements Filter
 {
-    public function filter(string $filepath, string $class, IOInterface $io): bool
+    public function filter(string $filepath, string $class, Logger $log): bool
     {
         $content = file_get_contents($filepath);
 
@@ -26,7 +26,7 @@ final class ContentFilter implements Filter
 
         // Hint of an attribute class.
         if (preg_match('/#\[\\\?Attribute[\]\(]/', $content)) {
-            $io->debug("Discarding '$class' because it looks like an attribute");
+            $log->debug("Discarding '$class' because it looks like an attribute");
             return false;
         }
 

--- a/src/Filter/InterfaceFilter.php
+++ b/src/Filter/InterfaceFilter.php
@@ -2,22 +2,22 @@
 
 namespace olvlvl\ComposerAttributeCollector\Filter;
 
-use Composer\IO\IOInterface;
 use olvlvl\ComposerAttributeCollector\Filter;
+use olvlvl\ComposerAttributeCollector\Logger;
 use Throwable;
 
 use function interface_exists;
 
 final class InterfaceFilter implements Filter
 {
-    public function filter(string $filepath, string $class, IOInterface $io): bool
+    public function filter(string $filepath, string $class, Logger $log): bool
     {
         try {
             if (interface_exists($class)) {
                 return false;
             }
         } catch (Throwable $e) {
-            $io->warning("Discarding '$class' because an error occurred during loading: {$e->getMessage()}");
+            $log->warning("Discarding '$class' because an error occurred during loading: {$e->getMessage()}");
 
             return false;
         }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector;
+
+interface Logger
+{
+    public function debug(string|\Stringable $message): void;
+    public function warning(string|\Stringable $message): void;
+    public function error(string|\Stringable $message): void;
+}

--- a/src/Logger/ComposerLogger.php
+++ b/src/Logger/ComposerLogger.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace olvlvl\ComposerAttributeCollector\Logger;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Logger;
+
+final class ComposerLogger implements Logger
+{
+    public function __construct(
+        private IOInterface $io
+    ) {
+    }
+
+    public function debug(\Stringable|string $message): void
+    {
+        $this->io->debug($message);
+    }
+
+    public function warning(\Stringable|string $message): void
+    {
+        $this->io->warning($message);
+    }
+
+    public function error(\Stringable|string $message): void
+    {
+        $this->io->error($message);
+    }
+}

--- a/src/MemoizeAttributeCollector.php
+++ b/src/MemoizeAttributeCollector.php
@@ -2,7 +2,6 @@
 
 namespace olvlvl\ComposerAttributeCollector;
 
-use Composer\IO\IOInterface;
 use Throwable;
 
 use function array_filter;
@@ -35,7 +34,7 @@ class MemoizeAttributeCollector
     public function __construct(
         private ClassAttributeCollector $classAttributeCollector,
         private Datastore $datastore,
-        private IOInterface $io,
+        private Logger $log,
     ) {
         /** @phpstan-ignore-next-line */
         $this->state = $this->datastore->get(self::KEY);
@@ -66,9 +65,9 @@ class MemoizeAttributeCollector
             if ($timestamp < $mtime) {
                 if ($timestamp) {
                     $diff = $mtime - $timestamp;
-                    $this->io->debug("Refresh attributes of class '$class' in '$filepath' ($diff sec ago)");
+                    $this->log->debug("Refresh attributes of class '$class' in '$filepath' ($diff sec ago)");
                 } else {
-                    $this->io->debug("Collect attributes of class '$class' in '$filepath'");
+                    $this->log->debug("Collect attributes of class '$class' in '$filepath'");
                 }
 
                 try {
@@ -78,7 +77,7 @@ class MemoizeAttributeCollector
                         $propertyAttributes,
                     ] = $classAttributeCollector->collectAttributes($class);
                 } catch (Throwable $e) {
-                    $this->io->error(
+                    $this->log->error(
                         "Attribute collection failed for $class: {$e->getMessage()}",
                     );
                 }

--- a/src/MemoizeClassMapFilter.php
+++ b/src/MemoizeClassMapFilter.php
@@ -3,7 +3,6 @@
 namespace olvlvl\ComposerAttributeCollector;
 
 use Closure;
-use Composer\IO\IOInterface;
 
 use function array_filter;
 use function filemtime;
@@ -26,7 +25,7 @@ class MemoizeClassMapFilter
 
     public function __construct(
         private Datastore $datastore,
-        private IOInterface $io,
+        private Logger $io,
     ) {
         /** @phpstan-ignore-next-line */
         $this->state = $this->datastore->get(self::KEY);

--- a/src/MemoizeClassMapGenerator.php
+++ b/src/MemoizeClassMapGenerator.php
@@ -3,7 +3,6 @@
 namespace olvlvl\ComposerAttributeCollector;
 
 use Composer\ClassMapGenerator\ClassMapGenerator;
-use Composer\IO\IOInterface;
 use DirectoryIterator;
 use RuntimeException;
 
@@ -38,7 +37,7 @@ class MemoizeClassMapGenerator
 
     public function __construct(
         private Datastore $datastore,
-        private IOInterface $io,
+        private Logger $log,
     ) {
         /** @phpstan-ignore-next-line */
         $this->state = $this->datastore->get(self::KEY);
@@ -107,7 +106,7 @@ class MemoizeClassMapGenerator
 
         if ($timestamp < $mtime) {
             $diff = $mtime - $timestamp;
-            $this->io->debug("Refresh class map for path '$path' ($diff sec ago)");
+            $this->log->debug("Refresh class map for path '$path' ($diff sec ago)");
 
             return true;
         }

--- a/tests/ClassAttributeCollectorTest.php
+++ b/tests/ClassAttributeCollectorTest.php
@@ -8,7 +8,6 @@ use Acme\PSR4\CreateMenuHandler;
 use Acme\PSR4\Presentation\ArticleController;
 use Acme\PSR4\SubscriberA;
 use Attribute;
-use Composer\IO\NullIO;
 use olvlvl\ComposerAttributeCollector\ClassAttributeCollector;
 use olvlvl\ComposerAttributeCollector\TransientTargetClass;
 use olvlvl\ComposerAttributeCollector\TransientTargetMethod;
@@ -24,7 +23,7 @@ final class ClassAttributeCollectorTest extends TestCase
     {
         parent::setUp();
 
-        $this->sut = new ClassAttributeCollector(new NullIO());
+        $this->sut = new ClassAttributeCollector(new FakeLogger());
     }
 
     /**

--- a/tests/FakeLogger.php
+++ b/tests/FakeLogger.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector;
+
+use olvlvl\ComposerAttributeCollector\Logger;
+
+final class FakeLogger implements Logger
+{
+    public function debug(\Stringable|string $message): void
+    {
+    }
+
+    public function warning(\Stringable|string $message): void
+    {
+    }
+
+    public function error(\Stringable|string $message): void
+    {
+    }
+}

--- a/tests/FileDatastoreTest.php
+++ b/tests/FileDatastoreTest.php
@@ -2,8 +2,8 @@
 
 namespace tests\olvlvl\ComposerAttributeCollector;
 
-use Composer\IO\IOInterface;
 use olvlvl\ComposerAttributeCollector\Datastore\FileDatastore;
+use olvlvl\ComposerAttributeCollector\Logger;
 use olvlvl\ComposerAttributeCollector\Plugin;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -16,15 +16,15 @@ final class FileDatastoreTest extends TestCase
     private const KEY = 'file-datastore';
 
     /**
-     * @var MockObject&IOInterface
+     * @var MockObject&Logger
      */
-    private MockObject|IOInterface $io;
+    private MockObject|Logger $log;
     private FileDatastore $sut;
 
     protected function setUp(): void
     {
-        $this->io = $this->createMock(IOInterface::class);
-        $this->sut = new FileDatastore(self::DIR, $this->io);
+        $this->log = $this->createMock(Logger::class);
+        $this->sut = new FileDatastore(self::DIR, $this->log);
 
         parent::setUp();
     }
@@ -33,7 +33,7 @@ final class FileDatastoreTest extends TestCase
     {
         $str = 'a:3:{i:0;i:2;i:1;i:3;i:2;i:5;}';
         $expected = [ 2, 3, 5 ];
-        $this->io
+        $this->log
             ->expects($this->never())
             ->method('warning')
             ->withAnyParameters();
@@ -49,7 +49,7 @@ final class FileDatastoreTest extends TestCase
     {
         $str = 'a:1:{i:0;E:12:"Priority:TOP";}';
         $expected = [];
-        $this->io
+        $this->log
             ->expects($this->atLeastOnce()) // PHP 8.2 also complains that the class 'Priority' is not found
             ->method('warning')
             ->with($this->stringStartsWith("Unable to unserialize cache item"));
@@ -67,7 +67,7 @@ final class FileDatastoreTest extends TestCase
 
         $str = 'a:1:{i:0;O:8:"Priority":1:{s:8:"priority";i:1;}}';
         $expected = [];
-        $this->io
+        $this->log
             ->expects($this->atLeastOnce())
             ->method('warning')
             ->with($this->stringStartsWith("Unable to unserialize cache item"));

--- a/tests/Filter/ContentFilterTest.php
+++ b/tests/Filter/ContentFilterTest.php
@@ -9,37 +9,37 @@
 
 namespace tests\olvlvl\ComposerAttributeCollector\Filter;
 
-use Composer\IO\IOInterface;
 use olvlvl\ComposerAttributeCollector\Filter\ContentFilter;
+use olvlvl\ComposerAttributeCollector\Logger;
 use PHPUnit\Framework\MockObject\MockObject as MockObjectAlias;
 use PHPUnit\Framework\TestCase;
 
 final class ContentFilterTest extends TestCase
 {
     private ContentFilter $sut;
-    private MockObjectAlias|IOInterface $io;
+    private MockObjectAlias|Logger $log;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->sut = new ContentFilter();
-        $this->io = $this->getMockBuilder(IOInterface::class)->getMock();
+        $this->log = $this->getMockBuilder(Logger::class)->getMock();
     }
 
     /**
      * @dataProvider provideAttribute
      */
-    public function testAttribute(string $case)
+    public function testAttribute(string $case): void
     {
-        $this->io->expects($this->once())
+        $this->log->expects($this->once())
             ->method('debug')
             ->with("Discarding '$case' because it looks like an attribute");
 
         $actual = $this->sut->filter(
             __DIR__ . "/ContentFilterCases/$case.php",
             $case,
-            $this->io
+            $this->log
         );
 
         $this->assertFalse($actual);
@@ -60,16 +60,16 @@ final class ContentFilterTest extends TestCase
     /**
      * @@dataProvider provideClass
      */
-    public function testClass(string $case, bool $expected)
+    public function testClass(string $case, bool $expected): void
     {
-        $this->io->expects($this->never())
+        $this->log->expects($this->never())
             ->method('debug')
             ->with($this->anything());
 
         $actual = $this->sut->filter(
             __DIR__ . "/ContentFilterCases/$case.php",
             $case,
-            $this->io
+            $this->log
         );
 
         $this->assertEquals($expected, $actual);

--- a/tests/Logger/ComposerLoggerTest.php
+++ b/tests/Logger/ComposerLoggerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace tests\olvlvl\ComposerAttributeCollector\Logger;
+
+use Composer\IO\IOInterface;
+use olvlvl\ComposerAttributeCollector\Logger\ComposerLogger;
+use PHPUnit\Framework\TestCase;
+
+final class ComposerLoggerTest extends TestCase
+{
+    public function testDebug(): void
+    {
+        $message = uniqid();
+        $io = $this->createMock(IOInterface::class);
+        $io->expects(self::once())->method('debug')->with($message);
+
+        $log =  new ComposerLogger($io);
+        $log->debug($message);
+    }
+
+    public function testWarning(): void
+    {
+        $message = uniqid();
+        $io = $this->createMock(IOInterface::class);
+        $io->expects(self::once())->method('warning')->with($message);
+
+        $log =  new ComposerLogger($io);
+        $log->warning($message);
+    }
+
+    public function testError(): void
+    {
+        $message = uniqid();
+        $io = $this->createMock(IOInterface::class);
+        $io->expects(self::once())->method('error')->with($message);
+
+        $log =  new ComposerLogger($io);
+        $log->error($message);
+    }
+}

--- a/tests/MemoizeClassMapGeneratorTest.php
+++ b/tests/MemoizeClassMapGeneratorTest.php
@@ -2,7 +2,6 @@
 
 namespace tests\olvlvl\ComposerAttributeCollector;
 
-use Composer\IO\NullIO;
 use olvlvl\ComposerAttributeCollector\Datastore\FileDatastore;
 use olvlvl\ComposerAttributeCollector\MemoizeClassMapGenerator;
 use PHPUnit\Framework\TestCase;
@@ -100,10 +99,10 @@ final class MemoizeClassMapGeneratorTest extends TestCase
      */
     private static function map(string $path): array
     {
-        $io = new NullIO();
+        $log = new FakeLogger();
         $generator = new MemoizeClassMapGenerator(
-            new FileDatastore(get_cache_dir(), $io),
-            $io,
+            new FileDatastore(get_cache_dir(), $log),
+            $log,
         );
 
         $generator->scanPaths($path);

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -23,7 +23,6 @@ use Acme\Attribute\Resource;
 use Acme\Attribute\Route;
 use Acme\Attribute\Subscribe;
 use Acme\PSR4\Presentation\ArticleController;
-use Composer\IO\NullIO;
 use olvlvl\ComposerAttributeCollector\Attributes;
 use olvlvl\ComposerAttributeCollector\Config;
 use olvlvl\ComposerAttributeCollector\Plugin;
@@ -79,7 +78,7 @@ final class PluginTest extends TestCase
 
         Plugin::dump(
             $config,
-            new NullIO(),
+            new FakeLogger(),
         );
 
         $this->assertFileExists($filepath);


### PR DESCRIPTION
Because I'm aiming to run the collector as a separate command, I cannot rely on the `IOInterface` provided by Composer. This PR introduces the `Logger` interface to replace `IOInterface`.