### PR TITLE
doc: fix URL to Laravel demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Use cases are available to test the plugin in real conditions:
 
 - [Symfony](cases/symfony) A Symfony application, created with `symfony new`.
 
-- [Laravel](cases/symfony) A Laravel application, created with `laravel new`.
+- [Laravel](cases/laravel) A Laravel application, created with `laravel new`.
 
 
 


### PR DESCRIPTION
The link in the README to the Laravel app was linked to the Symfony app.